### PR TITLE
RE-225: :bug: Improve first boot & fix open push in background

### DIFF
--- a/inspector/an-inspector/ForgeModule/src/com/parse/ForgePushBroadcastReceiver.java
+++ b/inspector/an-inspector/ForgeModule/src/com/parse/ForgePushBroadcastReceiver.java
@@ -78,8 +78,16 @@ public class ForgePushBroadcastReceiver extends ParsePushBroadcastReceiver {
     }
 
     @Override
-    public void onPushOpen(Context context, Intent intent) {
-        ParseAnalytics.trackAppOpenedInBackground(intent);
+    public void onPushOpen(Context context, final Intent intent) {
+
+        // wait until Parse is initialized otherwise a NPE can happen
+        Parse.registerParseCallbacks(new Parse.ParseCallbacks() {
+            @Override
+            public void onParseInitialized() {
+                ParseAnalytics.trackAppOpenedInBackground(intent);
+                Parse.unregisterParseCallbacks(this);
+            }
+        });
 
         // can't we just call super?
         Intent activity = new Intent(context, ForgeActivity.class);

--- a/inspector/an-inspector/ForgeModule/src/com/parse/ForgePushBroadcastReceiver.java
+++ b/inspector/an-inspector/ForgeModule/src/com/parse/ForgePushBroadcastReceiver.java
@@ -80,14 +80,18 @@ public class ForgePushBroadcastReceiver extends ParsePushBroadcastReceiver {
     @Override
     public void onPushOpen(Context context, final Intent intent) {
 
-        // wait until Parse is initialized otherwise a NPE can happen
-        Parse.registerParseCallbacks(new Parse.ParseCallbacks() {
-            @Override
-            public void onParseInitialized() {
-                ParseAnalytics.trackAppOpenedInBackground(intent);
-                Parse.unregisterParseCallbacks(this);
-            }
-        });
+        if (Parse.isInitialized()) {
+            ParseAnalytics.trackAppOpenedInBackground(intent);
+        } else {
+            // wait until Parse is initialized otherwise a NPE can happen
+            Parse.registerParseCallbacks(new Parse.ParseCallbacks() {
+                @Override
+                public void onParseInitialized() {
+                    ParseAnalytics.trackAppOpenedInBackground(intent);
+                    Parse.unregisterParseCallbacks(this);
+                }
+            });
+        }
 
         // can't we just call super?
         Intent activity = new Intent(context, ForgeActivity.class);

--- a/inspector/an-inspector/ForgeModule/src/io/trigger/forge/android/modules/parse/EventListener.java
+++ b/inspector/an-inspector/ForgeModule/src/io/trigger/forge/android/modules/parse/EventListener.java
@@ -42,8 +42,9 @@ public class EventListener extends ForgeEventListener {
                 @Override
                 public void onComplete(@NonNull Task<InstanceIdResult> task) {
                     // the deviceToken is available -> init parse
-                    ForgeLog.d("com.parse.push obtained deviceToken: " + task.getResult().getToken());
-                    initParse(parseConfig);
+                    String deviceToken = task.getResult().getToken();
+                    ForgeLog.d("com.parse.push obtained deviceToken: " + deviceToken);
+                    initParse(parseConfig, deviceToken);
                 }
             });
 
@@ -97,12 +98,10 @@ public class EventListener extends ForgeEventListener {
                 .build();
     }
 
-    private void initFirebase(final JsonObject config) {
-    }
-
-    private void initParse(Parse.Configuration parseConfig) {
+    private void initParse(Parse.Configuration parseConfig, final String deviceToken) {
         ForgeLog.d("com.parse.push initializing with parse");
         Parse.initialize(parseConfig);
+        ParseInstallation.getCurrentInstallation().setDeviceToken(deviceToken);
 
         ParseInstallation.getCurrentInstallation().saveInBackground(new SaveCallback() {
             @Override
@@ -113,14 +112,14 @@ public class EventListener extends ForgeEventListener {
                     return;
                 }
 
-                Object deviceToken = ParseInstallation.getCurrentInstallation().getDeviceToken();
-                if (deviceToken == null) {
-                    deviceToken = ParseInstallation.getCurrentInstallation().getDeviceToken();
-                    ForgeLog.e("com.parse.push deviceToken is null :-( " + deviceToken);
+                String parseDeviceToken = ParseInstallation.getCurrentInstallation().getDeviceToken();
+                if (parseDeviceToken == null) {
+                    parseDeviceToken = ParseInstallation.getCurrentInstallation().getDeviceToken();
+                    ForgeLog.e("com.parse.push deviceToken is null :-( " + parseDeviceToken);
                     return;
                 }
 
-                ForgeLog.i("com.parse.push initialized successfully, deviceToken: " + deviceToken);
+                ForgeLog.i("com.parse.push initialized successfully, deviceToken: " + parseDeviceToken);
 
                 ParsePush.subscribeInBackground("", new SaveCallback() {
                     @Override

--- a/module/manifest.json
+++ b/module/manifest.json
@@ -10,5 +10,5 @@
     "min_platform_version": "v2.7.4",
     "namespace": "parse",
     "platform_version": "v2.7.4",
-    "version": "3.3.3"
+    "version": "3.3.4"
 }

--- a/module/manifest.json
+++ b/module/manifest.json
@@ -10,5 +10,5 @@
     "min_platform_version": "v2.7.4",
     "namespace": "parse",
     "platform_version": "v2.7.4",
-    "version": "3.2.3"
+    "version": "3.3.3"
 }


### PR DESCRIPTION
We did two things here:

1. set the deviceToken we obtained from FCM to parse, since on first app start it was sometimes null.
2. wait until parse is initialized, before trackAppOpenedInBackground to avoid NPE